### PR TITLE
fix: remove preinstall check

### DIFF
--- a/.changeset/fuzzy-yaks-speak.md
+++ b/.changeset/fuzzy-yaks-speak.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-address": patch
+---
+
+Remove preinstall check script

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "npx only-allow-pnpm",
     "prepare": "npx simple-git-hooks",
     "build": "tsc --project tsconfig.build.json",
     "prebuild": "pnpm clean",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on removing the preinstall check script and updating the package.json file.

### Detailed summary
- Removed the "preinstall" script from the package.json file.
- Added "eslint-plugin-address" as a patch dependency in the package.json file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->